### PR TITLE
fix: schedule fake player spawn on server thread

### DIFF
--- a/src/main/java/com/sakuraryoko/unplugged_afk/impl/player/unplugged/UnpluggedServerPlayer.java
+++ b/src/main/java/com/sakuraryoko/unplugged_afk/impl/player/unplugged/UnpluggedServerPlayer.java
@@ -265,7 +265,7 @@ public class UnpluggedServerPlayer extends ServerPlayer
 			//$$ {
 				//$$ temp = p;
 			//$$ }
-			//$$ createFromConfigPhase2(server, level, temp, state, pos, game);
+			//$$ server.execute(() -> createFromConfigPhase2(server, level, temp, state, pos, game));
 		//$$ });
 		//#elseif MC >= 1.20.2
 		//$$ GameProfile tempProfile = profile;


### PR DESCRIPTION
Fix fake player spawning with C2ME.

The player was created from an async callback, causing C2ME's `Async entity load` error.

Queue player creation on the server thread instead.