### PR TITLE
[feature] add support for offline mode GUIDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ bin/
 # fabric
 
 run/
+AGENTS.md
+fabric-server-launcher.properties

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -24,7 +24,8 @@
         "resetHealthUponDeath": false,
         "unpluggedDisableDamage": false,
         "unpluggedHidePlayer": false,
-        "unpluggedHideFromOps": false
+        "unpluggedHideFromOps": false,
+        "offlineMode": false
     },
     "messages": {
         "broadcastMessages": false,

--- a/README.md
+++ b/README.md
@@ -8,64 +8,71 @@
 ![InfoGraphic](https://github.com/sakura-ryoko/unplugged-afk/blob/master/Infographic_hd.png?raw=true)
 
 ## Prerequisites & Installation
-* **Mod Loader:** Fabric
-* **Minecraft Version:** 1.19.2 up to 26.2
+
+- **Mod Loader:** Fabric
+- **Minecraft Version:** 1.19.2 up to 26.2
 
 ## Features
-* **Go Green:** Turn off your PC while your player-bot continues to AFK for you.
-* **Customizable Timeouts:** Set specific durations for how long a bot should remain active. The default timeout is 129600 minutes (90 days).
-* **Admin Control:** Server administrators have full command control to spawn, kick, or manage unplugged players.
-* **Safety Options:** Configurations allow you to reset health upon death, disable damage for unplugged players, or even hide them from other players and operators.
-* **Server Restart:** The mod also respawns all AFK bots at server restart with a slight delay.
+
+- **Go Green:** Turn off your PC while your player-bot continues to AFK for you.
+- **Customizable Timeouts:** Set specific durations for how long a bot should remain active. The default timeout is 129600 minutes (90 days).
+- **Admin Control:** Server administrators have full command control to spawn, kick, or manage unplugged players.
+- **Safety Options:** Configurations allow you to reset health upon death, disable damage for unplugged players, or even hide them from other players and operators.
+- **Server Restart:** The mod also respawns all AFK bots at server restart with a slight delay.
 
 ## Commands
 
 ### Player Commands
-* **`/unplug [<minutes>] [<reason>]`**: Disconnects you and leaves an unplugged bot in your place.
-  * *Note: This command cannot be used by the single-player server owner*.
+
+- **`/unplug [<minutes>] [<reason>]`**: Disconnects you and leaves an unplugged bot in your place.
+  - *Note: This command cannot be used by the single-player server owner*.
 
 ### Admin Commands
+
 Requires permission level 3 by default.
-* **`/unplugged-admin`**: Displays information about the mod.
-* **`/unplugged-admin save`**: Saves the current configuration.
-* **`/unplugged-admin reload`**: Reloads the configuration, overwriting the current configuration.
-* **`/unplugged-admin purge`**: Purges players and resyncs the current player/unplugged maps with the live server.
-* **`/unplugged-admin spawn <player> [<minutes>] [<reason>]`**: Manually spawns an unplugged bot for a specified player.
-* **`/unplugged-admin kick <player>`**: Removes/kicks an active unplugged bot.
-* **`/unplugged-admin info [<player>]`**: Displays detailed debug information for a specific player. (`advancedAdminOptions` enables the full "player" info)
-* **`/unplugged-admin list [players|unplugged|all]`**: Lists currently tracked players or active unplugged bots. (`advancedAdminOptions` enables the list sub commands)
-* **`/unplugged-admin set <setting> <value>`**: Sets a config setting value. (`advancedAdminOptions` enables this sub command)
+
+- **`/unplugged-admin`**: Displays information about the mod.
+- **`/unplugged-admin save`**: Saves the current configuration.
+- **`/unplugged-admin reload`**: Reloads the configuration, overwriting the current configuration.
+- **`/unplugged-admin purge`**: Purges players and resyncs the current player/unplugged maps with the live server.
+- **`/unplugged-admin spawn <player> [<minutes>] [<reason>]`**: Manually spawns an unplugged bot for a specified player.
+- **`/unplugged-admin kick <player>`**: Removes/kicks an active unplugged bot.
+- **`/unplugged-admin info [<player>]`**: Displays detailed debug information for a specific player. (`advancedAdminOptions` enables the full "player" info)
+- **`/unplugged-admin list [players|unplugged|all]`**: Lists currently tracked players or active unplugged bots. (`advancedAdminOptions` enables the list sub commands)
+- **`/unplugged-admin set <setting> <value>`**: Sets a config setting value. (`advancedAdminOptions` enables this sub command)
 
 ## Configuration
 
 The mod features a highly customizable `unplugged_afk.json` file. Key options include:
 
 | Category      | Option                             | Description                                                                                               | Default  |
-|:--------------|:-----------------------------------|:----------------------------------------------------------------------------------------------------------|:---------|
+| :------------ | :--------------------------------- | :-------------------------------------------------------------------------------------------------------- | :------- |
 | **Main**      | `unpluggedAfkEnabled`              | Toggles the entire AFK feature.                                                                           | `true`   |
 | **Main**      | `debugMode`                        | Enables debugging output.                                                                                 | `false`  |
 | **Main**      | `reducedListDebugInfo`             | Enables Reduced output for various information commands.                                                  | `true`   |
 | **Main**      | `advancedAdminOptions`             | Enables advanced Admin options, such as 'set'.                                                            | `false`  |
-| **Unplugged** | `defaultUnpluggedTimeout`          | Set the default timeout (in minutes).  The default is for 90 days.                                        | `129600` |
-| **Unplugged** | `resetHealthUponDeath`             | Resets the AFK bots Health when killed.                                                                   | `false`  |
-| **Unplugged** | `unpluggedDisableDamage`           | Prevents the AFK bot from taking damage.                                                                  | `false`  |
+| **Unplugged** | `defaultUnpluggedTimeout`          | Set the default timeout (in minutes).                                                                     | `129600` |
+| **Unplugged** | `resetHealthUponDeath`             | Resets the health of the unplugged bot when killed.                                                       | `false`  |
+| **Unplugged** | `unpluggedDisableDamage`           | Prevents the unplugged bot from taking damage.                                                            | `false`  |
 | **Unplugged** | `unpluggedHidePlayer`              | Makes the bot invisible to others.                                                                        | `false`  |
-| **Unplugged** | `unpluggedHideFromOps`             | Makes the bot invisible to to Operators as well.                                                          | `false`  |
+| **Unplugged** | `unpluggedHideFromOps`             | Makes the bot invisible to Operators.                                                                     | `false`  |
+| **Unplugged** | `offlineMode`                      | Enables deterministic UUIDs for offline mode servers.                                                     | `false`  |
 | **Command**   | `unplugCommandPermissions`         | Permission level required to use `/unplug`.                                                               | `0`      |
-| **Command**   | `unpluggedAdminCommandPermissions` | Permission level for `/unplugged-admin`.                                                                  | `3`      |
+| **Command**   | `unpluggedAdminCommandPermissions` | Permission level required to use `/unplugged-admin`.                                                      | `3`      |
 | **Command**   | `afkCommandPermissions`            | Permission level required to use `/afk`.                                                                  | `0`      |
 | **Command**   | `enableUnplugCommand`              | Enables the `/unplug` Command.                                                                            | `true`   |
 | **Command**   | `enableAfkCommand`                 | Enables the `/afk` Command. (Works the same as `/unplug`)                                                 | `false`  |
 | **Messages**  | `broadcastMessages`                | Enables the broadcasting of Unplugged status messages.                                                    | `false`  |
 | **Messages**  | `hideUnpluggedJoin`                | Enables the disabling of the default `player has joined` messages while bots are spawned, where possible. | `false`  |
 | **Messages**  | `displayDuration`                  | Enables the duration display of Unplugged status messages.                                                | `false`  |
-| **Messages**  | `displayReturnFeedback`            | Enables the Feedback display of the reason why an Unplugged session ended                                 | `false`  |
+| **Messages**  | `displayReturnFeedback`            | Enables the Feedback display of the reason why an Unplugged session ended.                                | `false`  |
 
 **Messages & Formatting:**
 Server owners can extensively customize broadcast messages and formatting. For example, the default kick message when a player successfully uses the command is `"§6Your player will be AFK§r"`.
 The `duration` and the `timeDate` are CoreLib time formatting options for the broadcast messages while `displayDuration` is enabled.
 
 ### Example Config
+
 [Click Here to open on GitHub](https://github.com/sakura-ryoko/unplugged-afk/blob/master/CONFIG.md)
 
 [![Join Sakura's RyokoCraft Discord](https://sakuraryoko.com/files/1398873/discord-300px.png)](https://discord.gg/ryokocraftmc)

--- a/src/main/java/com/sakuraryoko/unplugged_afk/api/state/GameState.java
+++ b/src/main/java/com/sakuraryoko/unplugged_afk/api/state/GameState.java
@@ -23,9 +23,12 @@ package com.sakuraryoko.unplugged_afk.api.state;
 import java.util.Objects;
 import org.jspecify.annotations.NonNull;
 
+import com.google.gson.annotations.JsonAdapter;
+
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 
+import com.sakuraryoko.unplugged_afk.impl.config.data.gson.GameStateAdapter;
 import com.sakuraryoko.unplugged_afk.impl.modinit.InitWrap;
 import com.sakuraryoko.unplugged_afk.impl.player.wrap.GameWrap;
 
@@ -35,6 +38,7 @@ import com.sakuraryoko.unplugged_afk.impl.player.wrap.GameWrap;
  * @param gameMode Game Mode
  * @param flying isFlying
  */
+@JsonAdapter(GameStateAdapter.class)
 public record GameState(String gameMode, boolean flying)
 {
 	@Override

--- a/src/main/java/com/sakuraryoko/unplugged_afk/api/state/PosState.java
+++ b/src/main/java/com/sakuraryoko/unplugged_afk/api/state/PosState.java
@@ -23,10 +23,13 @@ package com.sakuraryoko.unplugged_afk.api.state;
 import javax.annotation.Nonnull;
 import org.jspecify.annotations.NonNull;
 
+import com.google.gson.annotations.JsonAdapter;
+
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.server.level.ServerPlayer;
 
+import com.sakuraryoko.unplugged_afk.impl.config.data.gson.PosStateAdapter;
 import com.sakuraryoko.unplugged_afk.impl.modinit.InitWrap;
 import com.sakuraryoko.unplugged_afk.impl.player.wrap.PosWrap;
 
@@ -39,6 +42,7 @@ import com.sakuraryoko.unplugged_afk.impl.player.wrap.PosWrap;
  * @param yaw Entity Yaw (XRot)
  * @param pitch Entity Rotation (YRot)
  */
+@JsonAdapter(PosStateAdapter.class)
 public record PosState(String location, int x, int y, int z, float yaw, float pitch)
 {
 	@Override

--- a/src/main/java/com/sakuraryoko/unplugged_afk/api/state/UnpluggedState.java
+++ b/src/main/java/com/sakuraryoko/unplugged_afk/api/state/UnpluggedState.java
@@ -22,10 +22,13 @@ package com.sakuraryoko.unplugged_afk.api.state;
 
 import org.jspecify.annotations.NonNull;
 
+import com.google.gson.annotations.JsonAdapter;
+
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 
 import com.sakuraryoko.unplugged_afk.impl.config.ConfigWrap;
+import com.sakuraryoko.unplugged_afk.impl.config.data.gson.UnpluggedStateAdapter;
 import com.sakuraryoko.unplugged_afk.impl.modinit.InitWrap;
 
 /**
@@ -37,6 +40,7 @@ import com.sakuraryoko.unplugged_afk.impl.modinit.InitWrap;
  * @param startTime Starting Epoch Time in ms
  * @param reason Reason why
  */
+@JsonAdapter(UnpluggedStateAdapter.class)
 public record UnpluggedState(UnpluggedStatus status, int time, long timeout, long startTime, String reason)
 {
 	public static final UnpluggedState DEFAULT = new UnpluggedState(UnpluggedStatus.INACTIVE, 129600, -1L, -1L, "");

--- a/src/main/java/com/sakuraryoko/unplugged_afk/impl/config/data/gson/GameStateAdapter.java
+++ b/src/main/java/com/sakuraryoko/unplugged_afk/impl/config/data/gson/GameStateAdapter.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of the Unplugged-AFK project, licensed under the
+ * GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2026  Sakura-Ryoko and contributors
+ *
+ * Unplugged-AFK is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Unplugged-AFK is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Unplugged-AFK.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sakuraryoko.unplugged_afk.impl.config.data.gson;
+
+import java.io.IOException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import org.jetbrains.annotations.ApiStatus;
+
+import com.sakuraryoko.unplugged_afk.api.state.GameState;
+
+/**
+ * Gson TypeAdapter for {@link GameState}.
+ *
+ * <p>Java records have {@code final} fields, which Gson versions before 2.10
+ * (e.g. 2.8.9 bundled with Minecraft 1.19.2) cannot deserialize reflectively.
+ * This adapter lets the config load on every supported Gson version (2.8.9+).
+ */
+@ApiStatus.Internal
+public class GameStateAdapter extends TypeAdapter<GameState>
+{
+	@Override
+	public void write(JsonWriter out, GameState value) throws IOException
+	{
+		if (value == null)
+		{
+			out.nullValue();
+			return;
+		}
+
+		out.beginObject();
+		out.name("gameMode").value(value.gameMode());
+		out.name("flying").value(value.flying());
+		out.endObject();
+	}
+
+	@Override
+	public GameState read(JsonReader in) throws IOException
+	{
+		if (in.peek() == JsonToken.NULL)
+		{
+			in.nextNull();
+			return null;
+		}
+
+		String gameMode = "survival";
+		boolean flying = false;
+
+		in.beginObject();
+		while (in.hasNext())
+		{
+			String name = in.nextName();
+
+			switch (name)
+			{
+				case "gameMode" -> gameMode = in.nextString();
+				case "flying" -> flying = in.nextBoolean();
+				default -> in.skipValue();
+			}
+		}
+		in.endObject();
+
+		return new GameState(gameMode, flying);
+	}
+}

--- a/src/main/java/com/sakuraryoko/unplugged_afk/impl/config/data/gson/PosStateAdapter.java
+++ b/src/main/java/com/sakuraryoko/unplugged_afk/impl/config/data/gson/PosStateAdapter.java
@@ -1,0 +1,97 @@
+/*
+ * This file is part of the Unplugged-AFK project, licensed under the
+ * GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2026  Sakura-Ryoko and contributors
+ *
+ * Unplugged-AFK is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Unplugged-AFK is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Unplugged-AFK.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sakuraryoko.unplugged_afk.impl.config.data.gson;
+
+import java.io.IOException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import org.jetbrains.annotations.ApiStatus;
+
+import com.sakuraryoko.unplugged_afk.api.state.PosState;
+
+/**
+ * Gson TypeAdapter for {@link PosState}.
+ *
+ * <p>Java records have {@code final} fields, which Gson versions before 2.10
+ * (e.g. 2.8.9 bundled with Minecraft 1.19.2) cannot deserialize reflectively.
+ * This adapter lets the config load on every supported Gson version (2.8.9+).
+ */
+@ApiStatus.Internal
+public class PosStateAdapter extends TypeAdapter<PosState>
+{
+	@Override
+	public void write(JsonWriter out, PosState value) throws IOException
+	{
+		if (value == null)
+		{
+			out.nullValue();
+			return;
+		}
+
+		out.beginObject();
+		out.name("location").value(value.location());
+		out.name("x").value(value.x());
+		out.name("y").value(value.y());
+		out.name("z").value(value.z());
+		out.name("yaw").value(value.yaw());
+		out.name("pitch").value(value.pitch());
+		out.endObject();
+	}
+
+	@Override
+	public PosState read(JsonReader in) throws IOException
+	{
+		if (in.peek() == JsonToken.NULL)
+		{
+			in.nextNull();
+			return null;
+		}
+
+		String location = "minecraft:overworld";
+		int x = 0;
+		int y = 0;
+		int z = 0;
+		float yaw = 0.0f;
+		float pitch = 0.0f;
+
+		in.beginObject();
+		while (in.hasNext())
+		{
+			String name = in.nextName();
+
+			switch (name)
+			{
+				case "location" -> location = in.nextString();
+				case "x" -> x = in.nextInt();
+				case "y" -> y = in.nextInt();
+				case "z" -> z = in.nextInt();
+				case "yaw" -> yaw = (float) in.nextDouble();
+				case "pitch" -> pitch = (float) in.nextDouble();
+				default -> in.skipValue();
+			}
+		}
+		in.endObject();
+
+		return new PosState(location, x, y, z, yaw, pitch);
+	}
+}

--- a/src/main/java/com/sakuraryoko/unplugged_afk/impl/config/data/gson/UnpluggedStateAdapter.java
+++ b/src/main/java/com/sakuraryoko/unplugged_afk/impl/config/data/gson/UnpluggedStateAdapter.java
@@ -1,0 +1,115 @@
+/*
+ * This file is part of the Unplugged-AFK project, licensed under the
+ * GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2026  Sakura-Ryoko and contributors
+ *
+ * Unplugged-AFK is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Unplugged-AFK is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Unplugged-AFK.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sakuraryoko.unplugged_afk.impl.config.data.gson;
+
+import java.io.IOException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import org.jetbrains.annotations.ApiStatus;
+
+import com.sakuraryoko.unplugged_afk.api.state.UnpluggedState;
+import com.sakuraryoko.unplugged_afk.api.state.UnpluggedStatus;
+
+/**
+ * Gson TypeAdapter for {@link UnpluggedState}.
+ *
+ * <p>Java records have {@code final} fields, which Gson versions before 2.10
+ * (e.g. 2.8.9 bundled with Minecraft 1.19.2) cannot deserialize reflectively.
+ * This adapter lets the config load on every supported Gson version (2.8.9+).
+ */
+@ApiStatus.Internal
+public class UnpluggedStateAdapter extends TypeAdapter<UnpluggedState>
+{
+	@Override
+	public void write(JsonWriter out, UnpluggedState value) throws IOException
+	{
+		if (value == null)
+		{
+			out.nullValue();
+			return;
+		}
+
+		out.beginObject();
+		out.name("status").value(value.status().name());
+		out.name("time").value(value.time());
+		out.name("timeout").value(value.timeout());
+		out.name("startTime").value(value.startTime());
+		out.name("reason").value(value.reason());
+		out.endObject();
+	}
+
+	@Override
+	public UnpluggedState read(JsonReader in) throws IOException
+	{
+		if (in.peek() == JsonToken.NULL)
+		{
+			in.nextNull();
+			return null;
+		}
+
+		UnpluggedStatus status = UnpluggedStatus.INACTIVE;
+		int time = 129600;
+		long timeout = -1L;
+		long startTime = -1L;
+		String reason = "";
+
+		in.beginObject();
+		while (in.hasNext())
+		{
+			String name = in.nextName();
+
+			switch (name)
+			{
+				case "status" -> status = this.readStatus(in);
+				case "time" -> time = in.nextInt();
+				case "timeout" -> timeout = in.nextLong();
+				case "startTime" -> startTime = in.nextLong();
+				case "reason" -> reason = in.nextString();
+				default -> in.skipValue();
+			}
+		}
+		in.endObject();
+
+		return new UnpluggedState(status, time, timeout, startTime, reason);
+	}
+
+	private UnpluggedStatus readStatus(JsonReader in) throws IOException
+	{
+		if (in.peek() == JsonToken.NULL)
+		{
+			in.nextNull();
+			return UnpluggedStatus.INACTIVE;
+		}
+
+		String value = in.nextString();
+
+		try
+		{
+			return UnpluggedStatus.valueOf(value);
+		}
+		catch (IllegalArgumentException err)
+		{
+			return UnpluggedStatus.INACTIVE;
+		}
+	}
+}

--- a/src/main/java/com/sakuraryoko/unplugged_afk/impl/config/data/options/UnpluggedOptions.java
+++ b/src/main/java/com/sakuraryoko/unplugged_afk/impl/config/data/options/UnpluggedOptions.java
@@ -31,6 +31,7 @@ public class UnpluggedOptions implements IConfigOption
 	public boolean unpluggedDisableDamage;
 	public boolean unpluggedHidePlayer;
 	public boolean unpluggedHideFromOps;
+	public boolean offlineMode;
 
 	public UnpluggedOptions()
 	{
@@ -45,6 +46,7 @@ public class UnpluggedOptions implements IConfigOption
 		this.unpluggedDisableDamage = false;
 		this.unpluggedHidePlayer = false;
 		this.unpluggedHideFromOps = false;
+		this.offlineMode = false;
 	}
 
 	@Override
@@ -57,6 +59,7 @@ public class UnpluggedOptions implements IConfigOption
 		this.unpluggedDisableDamage = opts.unpluggedDisableDamage;
 		this.unpluggedHidePlayer = opts.unpluggedHidePlayer;
 		this.unpluggedHideFromOps = opts.unpluggedHideFromOps;
+		this.offlineMode = opts.offlineMode;
 
 		return this;
 	}

--- a/src/main/java/com/sakuraryoko/unplugged_afk/impl/player/unplugged/UnpluggedServerPlayer.java
+++ b/src/main/java/com/sakuraryoko/unplugged_afk/impl/player/unplugged/UnpluggedServerPlayer.java
@@ -183,7 +183,21 @@ public class UnpluggedServerPlayer extends ServerPlayer
 		//#endif
 		GameProfile profile;
 
+		// Offline-mode ("cracked") servers derive a player's UUID from their
+		// username, and store player data under that UUID. When enabled, force
+		// the deterministic offline UUID so the fake player loads the correct
+		// inventory instead of a fresh one.
+		final boolean offlineMode = ConfigWrap.unplugged().offlineMode;
+
+		if (offlineMode)
+		{
+			uuid = ProfileWrap.offlineId(name);
+			opts.uuid = uuid;
+			profile = ProfileWrap.profile(uuid, name);
+		}
 		//#if MC >= 1.21.10
+		//$$ else
+		//$$ {
 		//$$ UUID tempUUID = OldUsersConverter.convertMobOwnerIfNecessary(server, name);
 		//$$ if (tempUUID != null && !tempUUID.equals(uuid))
 		//$$ {
@@ -196,21 +210,25 @@ public class UnpluggedServerPlayer extends ServerPlayer
 		//$$ }
 		//$$ server.services().nameToIdCache().resolveOfflineUsers(server.isDedicatedServer() && server.usesAuthentication());
 		//$$ profile = new GameProfile(uuid, name);
+		//$$ }
 		//#else
-		try
+		else
 		{
-			profile = server.getProfileCache().get(name).orElse(
-					  server.getProfileCache().get(uuid).orElse(null)
-			);
-		}
-		finally
-		{
-			GameProfileCache.setUsesAuthentication(server.isDedicatedServer() && server.usesAuthentication());
-		}
+			try
+			{
+				profile = server.getProfileCache().get(name).orElse(
+						  server.getProfileCache().get(uuid).orElse(null)
+				);
+			}
+			finally
+			{
+				GameProfileCache.setUsesAuthentication(server.isDedicatedServer() && server.usesAuthentication());
+			}
 
-		if (profile == null)
-		{
-			profile = new GameProfile(uuid, name);
+			if (profile == null)
+			{
+				profile = new GameProfile(uuid, name);
+			}
 		}
 		//#endif
 
@@ -251,7 +269,15 @@ public class UnpluggedServerPlayer extends ServerPlayer
 			return;
 		}
 
+		if (offlineMode)
+		{
+			// In offline mode the UUID is already forced above; skip the
+			// profile re-resolution which could swap in a different UUID.
+			createFromConfigPhase2(server, level, profile, state, pos, game);
+		}
 		//#if MC >= 1.21.10
+		//$$ else
+		//$$ {
 		//$$ server.services().nameToIdCache().resolveOfflineUsers(server.isDedicatedServer() && server.usesAuthentication());
 		//$$ fetchGameProfile(server, profile.id()).whenCompleteAsync((p, throwable) ->
 		//$$ {
@@ -267,7 +293,10 @@ public class UnpluggedServerPlayer extends ServerPlayer
 			//$$ }
 			//$$ createFromConfigPhase2(server, level, temp, state, pos, game);
 		//$$ });
+		//$$ }
 		//#elseif MC >= 1.20.2
+		//$$ else
+		//$$ {
 		//$$ GameProfile tempProfile = profile;
 		//$$ fetchGameProfile(profile.getName()).thenAccept(opt ->
 		//$$ {
@@ -278,15 +307,19 @@ public class UnpluggedServerPlayer extends ServerPlayer
 			//$$ }
 			//$$ createFromConfigPhase2(server, level, temp, state, pos, game);
 		//$$ });
+		//$$ }
 		//#else
-		if (profile.getProperties().containsKey("textures"))
+		else
 		{
-			AtomicReference<GameProfile> result = new AtomicReference<>();
-			SkullBlockEntity.updateGameprofile(profile, result::set);
-			profile = result.get();
-		}
+			if (profile.getProperties().containsKey("textures"))
+			{
+				AtomicReference<GameProfile> result = new AtomicReference<>();
+				SkullBlockEntity.updateGameprofile(profile, result::set);
+				profile = result.get();
+			}
 
-		createFromConfigPhase2(server, level, profile, state, pos, game);
+			createFromConfigPhase2(server, level, profile, state, pos, game);
+		}
 		//#endif
 	}
 

--- a/src/main/java/com/sakuraryoko/unplugged_afk/impl/player/wrap/ProfileWrap.java
+++ b/src/main/java/com/sakuraryoko/unplugged_afk/impl/player/wrap/ProfileWrap.java
@@ -20,11 +20,13 @@
 
 package com.sakuraryoko.unplugged_afk.impl.player.wrap;
 
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import org.jetbrains.annotations.ApiStatus;
 
 import com.mojang.authlib.GameProfile;
 //#if MC >= 1.21.10
+//$$ import net.minecraft.core.UUIDUtil;
 //$$ import net.minecraft.server.players.NameAndId;
 //#endif
 
@@ -59,5 +61,19 @@ public class ProfileWrap
 	public static GameProfile profile(UUID id, String name)
 	{
 		return new GameProfile(id, name);
+	}
+
+	/**
+	 * Compute the deterministic offline-mode UUID for a player name.
+	 * This is the same UUID an offline-mode ("cracked") server assigns to a
+	 * player, and the UUID under which their player data is stored.
+	 */
+	public static UUID offlineId(String name)
+	{
+//#if MC >= 1.21.10
+		//$$ return UUIDUtil.createOfflinePlayerUUID(name);
+//#else
+		return UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes(StandardCharsets.UTF_8));
+//#endif
 	}
 }


### PR DESCRIPTION
> For full transparency, the following description and commits were generated by an LLM (specifically Deepseek V4 Flash)

On offline-mode (cracked) servers a player's UUID is derived from their username and player data is stored under that UUID. createFromConfig was re-resolving the profile through the profile cache / OldUsersConverter / async fetchGameProfile, which could return a different UUID and cause the fake player to load a fresh (empty) inventory after a server restart.

Add an 'offlineMode' config option (default false). When enabled, force the deterministic offline UUID derived from the player name and skip profile re-resolution so the correct inventory is loaded.