### PR TITLE
fix: schedule fake player spawn on older versions

### DIFF
--- a/src/main/java/com/sakuraryoko/unplugged_afk/impl/player/unplugged/UnpluggedServerPlayer.java
+++ b/src/main/java/com/sakuraryoko/unplugged_afk/impl/player/unplugged/UnpluggedServerPlayer.java
@@ -271,12 +271,8 @@ public class UnpluggedServerPlayer extends ServerPlayer
 		//$$ GameProfile tempProfile = profile;
 		//$$ fetchGameProfile(profile.getName()).thenAccept(opt ->
 		//$$ {
-			//$$ GameProfile temp = tempProfile;
-			//$$ if (opt.isPresent())
-			//$$ {
-				//$$ temp = opt.get();
-			//$$ }
-			//$$ createFromConfigPhase2(server, level, temp, state, pos, game);
+			//$$ GameProfile temp = opt.orElse(tempProfile);
+			//$$ server.execute(() -> createFromConfigPhase2(server, level, temp, state, pos, game));
 		//$$ });
 		//#else
 		if (profile.getProperties().containsKey("textures"))


### PR DESCRIPTION
Apply the server-thread fix from #3 to Minecraft 1.20.2 through 1.21.9.